### PR TITLE
fix: remove the leading and trailing white spaces from image links

### DIFF
--- a/layouts/shortcodes/img-link.html
+++ b/layouts/shortcodes/img-link.html
@@ -1,5 +1,3 @@
-{{- $text := .Get 0 }}
-{{- $link := .Get 1 }}
-<a class="img-link" href="{{ $link }}">
-  {{- $text -}}
-</a>
+{{- $text := .Get 0 -}}
+{{- $link := .Get 1 -}}
+<a class="img-link" href="{{ $link }}">{{- $text -}}</a>


### PR DESCRIPTION
Fixed #11 